### PR TITLE
fixes array types to allow length > 1

### DIFF
--- a/quadtree.d.ts
+++ b/quadtree.d.ts
@@ -20,13 +20,13 @@ declare class Quadtree {
     max_levels: number;
     level: number;
     bounds: Quadtree.Rect;
-    objects: [Quadtree.Rect];
-    nodes: [Quadtree];
+    objects: Quadtree.Rect[];
+    nodes: Quadtree[];
 
     split(): void
-    getIndex(pRect: Quadtree.Rect): [number]
+    getIndex(pRect: Quadtree.Rect): number[]
     insert(pRect: Quadtree.Rect): void
-    retrieve(pRect: Quadtree.Rect): [Quadtree.Rect]
+    retrieve<T extends Quadtree.Rect>(pRect: Quadtree.Rect): T[]
     clear(): void
 }
 


### PR DESCRIPTION
The current types force the length of the properties `objects` and `nodes` to be 1. The same is true for `getIndex` and `retrieve`. 

With this fix typescript will stop complaining about things like this:

```typescript
const rects = tree.retrieve(rect);
console.log(rects[1].x); // Tuple type '[Rect]' of length '1' has no element at index '1'.ts(2493)
```